### PR TITLE
WIP: feat: partially plug Echoprompt for the interactive selections

### DIFF
--- a/ecs_connect/menu.py
+++ b/ecs_connect/menu.py
@@ -49,39 +49,29 @@ def make_choice(
         list_results = get_container_name(
             profile, cluster_name, task_name.partition("/")[2].partition("/")[2]
         )
-        menu_title = "Choose the container to connect"
 
     # choose_task
     elif choice == "task_arn":
         list_results = get_task_arn(profile, cluster_name, service_name)
-        menu_title = "Choose the task to list container from"
 
     # choose_service
     elif choice == "service_name":
         list_results = get_service_name(profile, cluster_name)
-        menu_title = "Choose the service to list task from"
 
     # choose_cluster
     elif choice == "cluster_name":
         list_results = get_cluster_name(profile)
-        menu_title = "Choose the cluster to list service from"
 
     # choose_credentials_profile
     elif choice == "profile_name":
         list_results = check_credentials()
-        menu_title = "Choose the credentials to use"
 
     # choose which type of credentials to use
     elif choice == "credentials_type":
         list_results = which_credentials()
-        menu_title = "Which type of credentials would you use"
 
     # choose which region to use
     elif choice == "region_name":
         list_results = which_region()
-        menu_title = "Choose the default AWS region to use"
 
-    # Display the menu
-    index_menu = display_menu(list_results, menu_title=menu_title)
-
-    return list_results[index_menu]
+    return list_results

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.26.13
 simple-term-menu==1.5.2
 typer[all]==0.6.1
 pytest==6.2.4
+echoprompt==0.1.0


### PR DESCRIPTION
I use it locally for following connection path : `AWS_CREDENTIALS_FILE > profile (default) > cluster > service`

Currently Echoprompt requires python >= 3.9 because of Trapdoor dependency. 
I can see if it's possible to target a lower python version in a future release if it is necessary.

TODO:
- use Echoprompt for all connection paths
- remove unused typer code