### PR TITLE
fix: remove launchType to avoid filtering too much

### DIFF
--- a/ecs_connect_cli/session.py
+++ b/ecs_connect_cli/session.py
@@ -39,7 +39,6 @@ def get_session(
                 response = client.list_services(
                     cluster=cluster_name,
                     maxResults=50,
-                    launchType="FARGATE",
                 )
 
             if action == "list_tasks":


### PR DESCRIPTION
This fixes the error:

```
│ ╭─────────────────────────────────── locals ───────────────────────────────────╮                 │
│ │ self = <repr-error "'InquirerPyListControl' object has no attribute 'text'"> │                 │
│ ╰──────────────────────────────────────────────────────────────────────────────╯                 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
InvalidArgument: argument choices cannot be empty
```

The launchType parameter on list_services is a filter, not a required field. AWS returns all services when it's omitted.